### PR TITLE
Add support for monthly runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To run:
     node index.js
 
 # Production environment
+
 Push to master is build automatically:
 https://console.cloud.google.com/cloud-build/triggers;region=global/edit/6c94f2be-f12a-4339-904e-fb9d10a88314?project=marine-cycle-97212
 
@@ -16,3 +17,10 @@ https://console.cloud.google.com/gcr/images/marine-cycle-97212/global/github.com
 
 The job is executed every monday at 9 by:
 https://console.cloud.google.com/run/jobs/details/europe-north1/floq-prod-timebot/executions?project=marine-cycle-97212
+
+# Testing
+
+There is no separate testing environment. In order to test:
+
+1. Deploy a new version to production.
+2. Execute the [Cloud Run Job](https://console.cloud.google.com/run/jobs/details/europe-north1/floq-prod-timebot/executions?authuser=1&project=marine-cycle-97212&supportedpurview=project) with overrides and add the env variable `DRY_RUN=true`. Execute with overrides is available through the drop-down next to the execute button.

--- a/index.ts
+++ b/index.ts
@@ -1,79 +1,110 @@
-import fetch from 'node-fetch';
-import { WebClient } from '@slack/web-api';
-import * as jwt from 'jsonwebtoken';
-import moment from 'moment';
+import fetch from "node-fetch";
+import { WebClient } from "@slack/web-api";
+import * as jwt from "jsonwebtoken";
+import moment from "moment";
 
 type Employee = {
   email: string;
   unregistered_days: number;
 };
 
-const apiUri = process.env.API_URI || 'https://api-test.floq.no';
-const slack = new WebClient(process.env.SLACK_API_TOKEN || '');
+const apiUri = process.env.API_URI || "https://api-test.floq.no";
+const slack = new WebClient(process.env.SLACK_API_TOKEN || "");
+const DRY_RUN = process.env.DRY_RUN === "true";
 
 const greetings = [
-  'God dag.',
-  'Insjill.',
-  '¡Buenos días!',
-  'Buongiorno.',
-  '¡Hola!',
-  'Hej!',
-  'Selamat pagi!',
-  'Guten tag.',
-  'Tjena!'
+  "God dag.",
+  "Insjill.",
+  "¡Buenos días!",
+  "Buongiorno.",
+  "¡Hola!",
+  "Hej!",
+  "Selamat pagi!",
+  "Guten tag.",
+  "Tjena!",
+  "Xin chào",
 ];
 
 function toDaysString(days: number): String {
   switch (days) {
     case 1:
-      return 'én dag';
+      return "én dag";
     case 2:
-      return 'to dager';
+      return "to dager";
     case 3:
-      return 'tre dager';
+      return "tre dager";
     case 4:
-      return 'fire dager';
+      return "fire dager";
     case 5:
-      return 'fem dager';
+      return "fem dager";
     default:
-      return 'et ukjent antall dager'
+      return "et ukjent antall dager";
   }
 }
 
-const notifySlackers = async () => {
-  const apiToken = jwt.sign({ role: 'root' }, process.env.API_JWT_SECRET || 'dev-secret-shhh');
+const isFirstOfMonth = moment().date() === 1;
+const isMonday = moment().day() === 1;
 
-  const firstDateOfLastWeek = moment().add(-1, 'week').startOf('isoWeek').locale('nb');
-  const lastDateOfLastWeek = moment().add(-1, 'week').endOf('isoWeek').locale('nb');
+const getStartAndEndDate = () => {
+  moment.locale("nb");
+  let startDate, endDate;
+
+  if (isFirstOfMonth && !isMonday) {
+    startDate = moment().startOf("isoWeek");
+    endDate = moment().subtract(1, "day");
+  } else {
+    startDate = moment().subtract(1, "week").startOf("isoWeek");
+    endDate = moment().subtract(1, "week").endOf("isoWeek");
+  }
+
+  return { startDate, endDate };
+};
+
+const getWeekString = () => {
+  if (isFirstOfMonth && !isMonday) {
+    return "denne uken";
+  }
+  return "sist uke";
+};
+
+const notifySlackers = async () => {
+  const apiToken = jwt.sign(
+    { role: "root" },
+    process.env.API_JWT_SECRET || "dev-secret-shhh"
+  );
+
+  const { startDate, endDate } = getStartAndEndDate();
 
   const body = JSON.stringify({
-    start_date: firstDateOfLastWeek.format('YYYY-MM-DD'),
-    end_date: lastDateOfLastWeek.format('YYYY-MM-DD')
+    start_date: startDate.format("YYYY-MM-DD"),
+    end_date: endDate.format("YYYY-MM-DD"),
   });
   console.info(`${apiUri}/rpc/time_tracking_status body`, body);
 
+  const employeeResponse = await fetch(`${apiUri}/rpc/time_tracking_status`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: body,
+  });
+  const employees = (await employeeResponse.json()) as Employee[];
+  console.info("time_tracking_status response", employees);
 
-  const employeeResponse = await fetch(
-    `${apiUri}/rpc/time_tracking_status`,
-    {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${apiToken}`,
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: body,
-    }
+  const notifiees = employees.filter(
+    ({ unregistered_days }) => unregistered_days > 0
   );
-  const employees = await employeeResponse.json() as Employee[];
-  console.info('time_tracking_status response', employees);
+  console.info("notifiees", notifiees);
 
-  const notifiees = employees.filter(({ unregistered_days }) => unregistered_days > 0);
-  console.info('notifiees', notifiees);
-
-  const { members: slackUsers, error: getUsersError } = await slack.users.list();
+  const { members: slackUsers, error: getUsersError } =
+    await slack.users.list();
   if (getUsersError) {
-    console.error("Got an error response when trying to get slack users ", getUsersError);
+    console.error(
+      "Got an error response when trying to get slack users ",
+      getUsersError
+    );
     return;
   }
   if (!slackUsers) {
@@ -81,90 +112,135 @@ const notifySlackers = async () => {
     return;
   }
 
-  const firstDate = firstDateOfLastWeek.format('Do MMMM');
-  const lastDate = lastDateOfLastWeek.format('Do MMMM');
+  const firstDate = startDate.format("Do MMMM");
+  const lastDate = endDate.format("Do MMMM");
 
   for (const { email, unregistered_days: days } of notifiees) {
-    const targetUser = slackUsers.find(u => u.profile!.email === email);
+    const targetUser = slackUsers.find((u) => u.profile!.email === email);
 
     if (targetUser === undefined) {
       console.error(`Slack user for email ${email} not found.`);
     } else {
       const greeting = greetings[Math.floor(Math.random() * greetings.length)];
 
-      const message = `${greeting} Det ser ut som De har glemt å føre ${toDaysString(days)} sist uke`
-        + ` (mellom ${firstDate} og ${lastDate}). Hvis du avspaserte: ignorer meg. 😳\n\n`
-        + 'Timeføring: https://inni.blank.no/timestamp/\n\n'
-        + 'P.S: Hvis jeg er veldig teit nå, kontakt @jahnarne. 😇';
+      const message =
+        `${greeting} Det ser ut som De har glemt å føre ${toDaysString(
+          days
+        )} ${getWeekString()}` +
+        ` (mellom ${firstDate} og ${lastDate}). Hvis du avspaserte: ignorer meg. 😳\n\n` +
+        "Timeføring: https://inni.blank.no/timestamp/\n\n" +
+        "P.S: Hvis jeg er veldig teit nå, kontakt @jahnarne. 😇";
 
-      console.info(`Notifying user @${targetUser.name} (id ${targetUser.id}) that s/he is missing ${days} day(s).`);
+      console.info(
+        `Notifying user @${targetUser.name} (id ${targetUser.id}) that s/he is missing ${days} day(s).`
+      );
       console.info(message);
 
-      const { ok, postMessageError } = await slack.chat.postMessage({ channel: targetUser.id, text: message, as_user: true });
+      if (DRY_RUN) {
+        console.info("Dry run, not actually sending any message");
+        continue;
+      }
+
+      const { ok, postMessageError } = await slack.chat.postMessage({
+        channel: targetUser.id,
+        text: message,
+        as_user: true,
+      });
       if (postMessageError) {
-        console.error(`Got an error response when trying to post message to ${targetUser.name}`, postMessageError);
+        console.error(
+          `Got an error response when trying to post message to ${targetUser.name}`,
+          postMessageError
+        );
         return;
       }
       if (!ok) {
-        console.error(`Message was not sent to ${targetUser.name} and response contained no error`);
+        console.error(
+          `Message was not sent to ${targetUser.name} and response contained no error`
+        );
         return;
       }
-      console.info('Message sent to', targetUser.name);
+      console.info("Message sent to", targetUser.name);
     }
   }
 };
 
 const notifyAdminAboutOvertime = async () => {
-  const apiToken = jwt.sign({ role: 'root' }, process.env.API_JWT_SECRET || 'dev-secret-shhh');
+  const apiToken = jwt.sign(
+    { role: "root" },
+    process.env.API_JWT_SECRET || "dev-secret-shhh"
+  );
 
-  const channelName = 'overtid';
+  const channelName = "overtid";
 
   const overtimeResponse = await fetch(
     `${apiUri}/paid_overtime?paid_date=is.null`,
     {
-      method: 'GET',
+      method: "GET",
       headers: {
-        'Authorization': `Bearer ${apiToken}`,
-        'Accept': 'application/json'
-      }
+        Authorization: `Bearer ${apiToken}`,
+        Accept: "application/json",
+      },
     }
   );
-  const entries = await overtimeResponse.json() as any[];
+  const entries = (await overtimeResponse.json()) as any[];
 
   if (entries.length > 0) {
-    const { channels, error: getChannelsError } = await slack.conversations.list({types: "public_channel,private_channel"});
+    const { channels, error: getChannelsError } =
+      await slack.conversations.list({
+        types: "public_channel,private_channel",
+      });
     if (getChannelsError) {
-      console.error('Got an error response when trying to get slack channels', getChannelsError);
+      console.error(
+        "Got an error response when trying to get slack channels",
+        getChannelsError
+      );
       return;
     }
     if (!channels) {
-      console.error('Found no slack channels');
+      console.error("Found no slack channels");
       return;
     }
 
     const channel = channels.find((c) => c.name === channelName);
     if (!channel) {
-      console.error(`Could not find any channel with a name matching "${channelName}"`);
+      console.error(
+        `Could not find any channel with a name matching "${channelName}"`
+      );
       return;
     }
 
     const greeting = greetings[Math.floor(Math.random() * greetings.length)];
-    const message = `${greeting} Det ser ut som noen har ført overtid som ikke er utbetalt💰\n\n`
-      + 'Overtid: https://inni.blank.no/overtime\n\n'
-      + 'P.S: Hvis jeg er veldig teit nå, kontakt @jahnarne. 😇';
+    const message =
+      `${greeting} Det ser ut som noen har ført overtid som ikke er utbetalt💰\n\n` +
+      "Overtid: https://inni.blank.no/overtime\n\n" +
+      "P.S: Hvis jeg er veldig teit nå, kontakt @jahnarne. 😇";
 
     console.info(message);
 
-    const { ok, postMessageError } = await slack.chat.postMessage({ channel: channel.id, text: message, as_user: true });
+    if (DRY_RUN) {
+      console.info("Dry run, not actually sending any message");
+      return;
+    }
+
+    const { ok, postMessageError } = await slack.chat.postMessage({
+      channel: channel.id,
+      text: message,
+      as_user: true,
+    });
     if (postMessageError) {
-      console.error('Got an error response when trying to post message about overtime', postMessageError);
+      console.error(
+        "Got an error response when trying to post message about overtime",
+        postMessageError
+      );
       return;
     }
     if (!ok) {
-      console.error(`Message was not sent to ${channelName} and response contained no error`);
+      console.error(
+        `Message was not sent to ${channelName} and response contained no error`
+      );
       return;
     }
-    console.info('Message sent to', channelName);
+    console.info("Message sent to", channelName);
   }
 };
 


### PR DESCRIPTION
* If job is ran on the first of the month and its not a Monday, check for `unregistered_days` in the current week. If it is Monday, check the previous week as normal.
* Add support for dry run (specified through the `DRY_RUN` environment variable) which performs everything as normal, but does not send any slack messages.
* Update wording to specify which week the `unregistered_days` are in
* Add Vietnamese greeting
* Add testing procedure to README.md