### PR TITLE
Reminder til oppdragsansvarlig om fakturering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ bundling, so every flow can be triggered and tested on its own.
 | `IS_FIRST_OF_MONTH` | Month nudge to people still missing hours for last month | DM to stragglers |
 | `IS_MONTHLY_RECAP` | Monthly recap (FG, bonus, project hours). Derived: fires on the first Monday of the month | DM to each employee |
 | `IS_OVERTIME` | Unpaid registered overtime exists | `#overtid` channel |
+| `IS_INVOICING_REMINDER` | Month-end reminder to invoice. Internal date gate fires it on the last virkedag of the month (rolled forward past weekends/holidays) | DM to each project's oppdragsansvarlig |
 | `IS_AVAILABILITY` | Free capacity (unstaffed days) the next N weeks, per person | capacity channel |
 | `IS_ADMIN_MISSING` | Aggregated table of who is missing time entries | capacity channel |
 
@@ -51,6 +52,8 @@ When testing there are some environment variables available for easier testing:
 | `IS_FIRST_OF_MONTH`  | Run the first-of-month nudge              | `false`       |
 | `IS_MONTHLY_RECAP`   | Force the monthly recap                   | `false`       |
 | `IS_OVERTIME`        | Run the unpaid-overtime check             | `false`       |
+| `IS_INVOICING_REMINDER` | Run the month-end invoicing reminder (still self-gates to the send-day) | `false`  |
+| `INVOICING_REMINDER_FORCE` | Bypass the invoicing send-day gate (targets the previous month) — for testing | `false` |
 | `IS_AVAILABILITY`    | Run the free-capacity overview            | `false`       |
 | `IS_ADMIN_MISSING`   | Run the aggregated missing-time table     | `false`       |
 
@@ -65,10 +68,19 @@ Configuration knobs (all have sensible defaults):
 | `CAPACITY_CHANNEL` | Channel for the availability and admin-missing overviews | `admin-bemanningogsalg-diskusjon` |
 | `CAPACITY_WEEKS_AHEAD` | How many ISO weeks ahead the availability overview covers | `6` |
 | `ADMIN_MISSING_PERIOD` | Period for `IS_ADMIN_MISSING`: `week` (last week) or `month` (last month) | `week` |
+| `FLOQ_INVOICE_URL` | Link in the invoicing reminder | `https://inni.blank.no/invoice` |
 
 Scheduling note: `IS_ADMIN_MISSING` is independent of the personal-nudge flags.
 To mirror the nudge cadence, set `IS_ADMIN_MISSING=true` on the Monday and
 Tuesday triggers, and `IS_ADMIN_MISSING=true` + `ADMIN_MISSING_PERIOD=month` on
 the first-of-month trigger.
+
+Scheduling note for `IS_INVOICING_REMINDER`: schedule a trigger that fires it
+**every weekday** with `IS_INVOICING_REMINDER=true`. The flow self-gates — it
+only sends on the month's last virkedag, rolled forward past weekends and
+holidays (so if the last day is a Saturday it lands the following Monday). Every
+other weekday it exits after one cheap holidays lookup. Firing it monthly would
+be wrong: the exact send date shifts month to month, so a fixed cron can't hit
+it.
 
 For reverting back to previous versions after testing, delete the latest image from the [Container Registry](https://console.cloud.google.com/gcr/images/marine-cycle-97212/global/github.com/blankoslo/floq-timebot?authuser=1&tab=info) or change the latest tag.

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,8 @@ const slack = new WebClient(process.env.SLACK_API_TOKEN || "");
 const DRY_RUN = process.env.DRY_RUN === "true";
 const FLOQ_TIMESTAMP_URL =
   process.env.FLOQ_TIMESTAMP_URL || "https://inni.blank.no/timestamp/";
+const FLOQ_INVOICE_URL =
+  process.env.FLOQ_INVOICE_URL || "https://inni.blank.no/invoice";
 // When set, only this employee's data is processed (filters the target
 // list) — useful for previewing how a real Slack render looks without
 // spamming everyone.
@@ -69,6 +71,13 @@ type ProjectRow = {
   name: string;
   // From floq: "billable" | "non_billable" | "unavailable" (verified via API)
   billable: string;
+};
+// `responsible` (oppdragsansvarlig) is an employees.id, nullable in the DB.
+type InvoiceProjectRow = {
+  id: string;
+  name: string;
+  billable: string;
+  responsible: number | null;
 };
 type FGPeriodRow = {
   employee_id: number;
@@ -181,6 +190,10 @@ const isAvailabilityCheck = process.env.IS_AVAILABILITY === "true";
 const isAdminMissing = process.env.IS_ADMIN_MISSING === "true";
 const adminMissingPeriod =
   process.env.ADMIN_MISSING_PERIOD === "month" ? "month" : "week";
+// Fired every weekday; notifyInvoicingResponsible self-gates to the send day.
+// INVOICING_REMINDER_FORCE bypasses that gate for testing (previous month).
+const isInvoicingReminder = process.env.IS_INVOICING_REMINDER === "true";
+const invoicingReminderForce = process.env.INVOICING_REMINDER_FORCE === "true";
 // The monthly recap rides along with the Monday run, but only on the first
 // Monday of the month (date 1–7) — by then every "majority-of-days-in-
 // previous-month" week has finished, so bonus + FG are stable. No separate
@@ -251,6 +264,16 @@ async function fetchAllAbsencesForWeek(
 
 async function fetchAllEmployees(): Promise<EmployeeRow[]> {
   return apiGet<EmployeeRow[]>("/employees?select=id,email");
+}
+
+async function fetchActiveBillableProjectsWithResponsible(): Promise<
+  InvoiceProjectRow[]
+> {
+  // billable is a text category; only "billable" projects get invoiced.
+  const rows = await apiGet<InvoiceProjectRow[]>(
+    "/projects?select=id,name,billable,responsible&active=eq.true&responsible=not.is.null"
+  );
+  return rows.filter((p) => p.billable === "billable" && p.responsible != null);
 }
 
 // Per-employee fetcher: throws on a real API error. Callers wrap the loop
@@ -902,6 +925,196 @@ const notifyAdminAboutOvertime = async () => {
     console.info(`Sent to #${channelName}`);
   } catch (err) {
     console.error(`Failed to post to #${channelName}:`, err);
+  }
+};
+
+// === Reminder til oppdragsansvarlig: fakturering ===
+//
+// DM every project's oppdragsansvarlig (projects.responsible) to invoice the
+// just-finished month. Send-day: the month's last day if it's a virkedag, else
+// rolled forward to the next virkedag (past weekends and holidays).
+
+// Last day of monthAnchor's month, rolled forward to the first virkedag on or
+// after it (isoWeekday 6/7 = Sat/Sun).
+function invoicingReminderSendDate(
+  monthAnchor: moment.Moment,
+  holidaySet: Set<string>
+): moment.Moment {
+  const d = monthAnchor.clone().endOf("month").startOf("day");
+  while (d.isoWeekday() >= 6 || holidaySet.has(d.format("YYYY-MM-DD"))) {
+    d.add(1, "day");
+  }
+  return d;
+}
+
+function buildInvoicingReminderMessage(
+  monthLabel: string,
+  projects: InvoiceProjectRow[]
+): { text: string; blocks: Array<Record<string, unknown>> } {
+  const projectLines = projects.map((p) => `• ${p.name} (${p.id})`).join("\n");
+  const ownsClause =
+    projects.length === 1
+      ? "dette oppdraget"
+      : `disse ${projects.length} oppdragene`;
+  const intro =
+    `Det er på tide å fakturere for *${monthLabel}* 🧾\n` +
+    `Du står som oppdragsansvarlig for ${ownsClause}:`;
+  const message = `${intro}\n${projectLines}`;
+
+  const text =
+    message.replace(/\*/g, "") + `\n\nÅpne fakturering: ${FLOQ_INVOICE_URL}`;
+
+  const blocks: Array<Record<string, unknown>> = [
+    { type: "section", text: { type: "mrkdwn", text: message } },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Åpne fakturering i Floq" },
+          url: FLOQ_INVOICE_URL,
+        },
+      ],
+    },
+  ];
+
+  return { text, blocks };
+}
+
+const notifyInvoicingResponsible = async () => {
+  const today = moment().startOf("day");
+
+  // Covers both roll windows: last month's start through past this month's end.
+  const holStart = today
+    .clone()
+    .subtract(1, "month")
+    .startOf("month")
+    .format("YYYY-MM-DD");
+  const holEnd = today
+    .clone()
+    .endOf("month")
+    .add(10, "days")
+    .format("YYYY-MM-DD");
+
+  let holidays: HolidayRow[];
+  try {
+    holidays = await fetchHolidays(holStart, holEnd);
+  } catch (err) {
+    console.error("holidays fetch failed:", err);
+    return;
+  }
+  const holidaySet = new Set(holidays.map((h) => h.date));
+
+  // A forward roll from a weekend/holiday month-end lands in the next month, so
+  // today's send-day may belong to this month (case A) or last month (case B).
+  let coveredMonth: moment.Moment;
+  if (invoicingReminderForce) {
+    coveredMonth = today.clone().subtract(1, "month");
+    console.info("INVOICING_REMINDER_FORCE — covering previous month.");
+  } else {
+    const thisMonthSend = invoicingReminderSendDate(today, holidaySet);
+    const prevMonthSend = invoicingReminderSendDate(
+      today.clone().subtract(1, "month"),
+      holidaySet
+    );
+    if (today.isSame(thisMonthSend, "day")) {
+      coveredMonth = today.clone();
+    } else if (today.isSame(prevMonthSend, "day")) {
+      coveredMonth = today.clone().subtract(1, "month");
+    } else {
+      const next = thisMonthSend.isAfter(today) ? thisMonthSend : prevMonthSend;
+      console.info(
+        `Not an invoicing reminder day (today=${today.format("YYYY-MM-DD")}, next=${next.format("YYYY-MM-DD")}). Skipping.`
+      );
+      return;
+    }
+  }
+  const monthLabel = coveredMonth.format("MMMM YYYY");
+
+  console.info(`Invoicing reminder for ${monthLabel}`);
+
+  let projects: InvoiceProjectRow[];
+  let allEmployees: EmployeeRow[];
+  let slackUsersResp: Awaited<ReturnType<typeof slack.users.list>>;
+  try {
+    [projects, allEmployees, slackUsersResp] = await Promise.all([
+      fetchActiveBillableProjectsWithResponsible(),
+      fetchAllEmployees(),
+      slack.users.list(),
+    ]);
+  } catch (err) {
+    console.error("invoicing reminder fetch failed:", err);
+    return;
+  }
+
+  const slackUsers = slackUsersResp.members;
+  if (!slackUsers) {
+    console.error("No slack users in response");
+    return;
+  }
+
+  const emailById = new Map(allEmployees.map((e) => [e.id, e.email]));
+
+  const projectsByResponsible = new Map<number, InvoiceProjectRow[]>();
+  for (const p of projects) {
+    const id = p.responsible!;
+    const list = projectsByResponsible.get(id);
+    if (list) list.push(p);
+    else projectsByResponsible.set(id, [p]);
+  }
+
+  console.info(
+    `${projects.length} billable project(s) across ${projectsByResponsible.size} oppdragsansvarlig`
+  );
+
+  if (projectsByResponsible.size === 0) {
+    console.info("No projects with an oppdragsansvarlig — nothing to send.");
+    return;
+  }
+
+  for (const [responsibleId, ownedProjects] of Array.from(
+    projectsByResponsible
+  )) {
+    const email = emailById.get(responsibleId);
+    if (!email) {
+      console.warn(`No email for responsible employee ${responsibleId}, skipping`);
+      continue;
+    }
+    if (TEST_USER_EMAIL && email.toLowerCase() !== TEST_USER_EMAIL) continue;
+
+    const targetUser = pickSlackRecipient(slackUsers, email);
+    if (!targetUser) {
+      console.error(`No Slack user found for ${email}`);
+      continue;
+    }
+
+    ownedProjects.sort((a, b) => a.name.localeCompare(b.name, "nb"));
+
+    const { text, blocks } = buildInvoicingReminderMessage(
+      monthLabel,
+      ownedProjects
+    );
+
+    console.info(
+      `Invoicing reminder → @${targetUser.name} (${email}) — ${ownedProjects.length} prosjekt(er)`
+    );
+
+    if (DRY_RUN) {
+      console.info("DRY_RUN — message preview:\n" + text);
+      continue;
+    }
+
+    try {
+      await slack.chat.postMessage({
+        channel: targetUser.id!,
+        text,
+        blocks: blocks as any,
+        as_user: true,
+      });
+      console.info(`Sent to @${targetUser.name}`);
+    } catch (err) {
+      console.error(`Failed to send to @${targetUser.name}:`, err);
+    }
   }
 };
 
@@ -1944,6 +2157,9 @@ const main = async () => {
   if (isAvailabilityCheck) {
     tasks.push(notifyAvailableConsultants());
   }
+  if (isInvoicingReminder) {
+    tasks.push(notifyInvoicingResponsible());
+  }
   if (isAdminMissing) {
     const period =
       adminMissingPeriod === "month"
@@ -1989,7 +2205,7 @@ const main = async () => {
 
   if (tasks.length === 0) {
     console.info(
-      `Nothing scheduled today (run with IS_MONDAY, IS_TUESDAY, IS_OVERTIME, IS_AVAILABILITY, IS_ADMIN_MISSING, IS_FIRST_OF_MONTH or IS_MONTHLY_RECAP=true to test).`
+      `Nothing scheduled today (run with IS_MONDAY, IS_TUESDAY, IS_OVERTIME, IS_AVAILABILITY, IS_INVOICING_REMINDER, IS_ADMIN_MISSING, IS_FIRST_OF_MONTH or IS_MONTHLY_RECAP=true to test).`
     );
     return;
   }

--- a/index.ts
+++ b/index.ts
@@ -72,12 +72,12 @@ type ProjectRow = {
   // From floq: "billable" | "non_billable" | "unavailable" (verified via API)
   billable: string;
 };
-// `responsible` (oppdragsansvarlig) is an employees.id, nullable in the DB.
+// `responsible` (oppdragsansvarlig) is an employees.id — nullable in the DB,
+// but the fetcher filters out null rows.
 type InvoiceProjectRow = {
   id: string;
   name: string;
-  billable: string;
-  responsible: number | null;
+  responsible: number;
 };
 type FGPeriodRow = {
   employee_id: number;
@@ -269,11 +269,9 @@ async function fetchAllEmployees(): Promise<EmployeeRow[]> {
 async function fetchActiveBillableProjectsWithResponsible(): Promise<
   InvoiceProjectRow[]
 > {
-  // billable is a text category; only "billable" projects get invoiced.
-  const rows = await apiGet<InvoiceProjectRow[]>(
-    "/projects?select=id,name,billable,responsible&active=eq.true&responsible=not.is.null"
+  return apiGet<InvoiceProjectRow[]>(
+    "/projects?select=id,name,responsible&active=eq.true&billable=eq.billable&responsible=not.is.null"
   );
-  return rows.filter((p) => p.billable === "billable" && p.responsible != null);
 }
 
 // Per-employee fetcher: throws on a real API error. Callers wrap the loop
@@ -996,13 +994,7 @@ const notifyInvoicingResponsible = async () => {
     .add(10, "days")
     .format("YYYY-MM-DD");
 
-  let holidays: HolidayRow[];
-  try {
-    holidays = await fetchHolidays(holStart, holEnd);
-  } catch (err) {
-    console.error("holidays fetch failed:", err);
-    return;
-  }
+  const holidays = await fetchHolidays(holStart, holEnd);
   const holidaySet = new Set(holidays.map((h) => h.date));
 
   // A forward roll from a weekend/holiday month-end lands in the next month, so
@@ -1033,19 +1025,11 @@ const notifyInvoicingResponsible = async () => {
 
   console.info(`Invoicing reminder for ${monthLabel}`);
 
-  let projects: InvoiceProjectRow[];
-  let allEmployees: EmployeeRow[];
-  let slackUsersResp: Awaited<ReturnType<typeof slack.users.list>>;
-  try {
-    [projects, allEmployees, slackUsersResp] = await Promise.all([
-      fetchActiveBillableProjectsWithResponsible(),
-      fetchAllEmployees(),
-      slack.users.list(),
-    ]);
-  } catch (err) {
-    console.error("invoicing reminder fetch failed:", err);
-    return;
-  }
+  const [projects, allEmployees, slackUsersResp] = await Promise.all([
+    fetchActiveBillableProjectsWithResponsible(),
+    fetchAllEmployees(),
+    slack.users.list(),
+  ]);
 
   const slackUsers = slackUsersResp.members;
   if (!slackUsers) {
@@ -1057,10 +1041,9 @@ const notifyInvoicingResponsible = async () => {
 
   const projectsByResponsible = new Map<number, InvoiceProjectRow[]>();
   for (const p of projects) {
-    const id = p.responsible!;
-    const list = projectsByResponsible.get(id);
+    const list = projectsByResponsible.get(p.responsible);
     if (list) list.push(p);
-    else projectsByResponsible.set(id, [p]);
+    else projectsByResponsible.set(p.responsible, [p]);
   }
 
   console.info(

--- a/index.ts
+++ b/index.ts
@@ -1062,7 +1062,7 @@ const notifyInvoicingResponsible = async () => {
   );
 
   if (projectsByResponsible.size === 0) {
-    console.info("No projects with an oppdragsansvarlig — nothing to send.");
+    console.info("Nothing to send for invoicing reminder.");
     return;
   }
 

--- a/index.ts
+++ b/index.ts
@@ -1039,15 +1039,26 @@ const notifyInvoicingResponsible = async () => {
 
   const emailById = new Map(allEmployees.map((e) => [e.id, e.email]));
 
+  let targets = projects;
+  if (TEST_USER_EMAIL) {
+    const before = targets.length;
+    targets = targets.filter(
+      (p) => emailById.get(p.responsible)?.toLowerCase() === TEST_USER_EMAIL
+    );
+    console.info(
+      `TEST_USER_EMAIL=${TEST_USER_EMAIL} — filtered ${before} → ${targets.length} target(s)`
+    );
+  }
+
   const projectsByResponsible = new Map<number, InvoiceProjectRow[]>();
-  for (const p of projects) {
+  for (const p of targets) {
     const list = projectsByResponsible.get(p.responsible);
     if (list) list.push(p);
     else projectsByResponsible.set(p.responsible, [p]);
   }
 
   console.info(
-    `${projects.length} billable project(s) across ${projectsByResponsible.size} oppdragsansvarlig`
+    `${targets.length} billable project(s) across ${projectsByResponsible.size} oppdragsansvarlig`
   );
 
   if (projectsByResponsible.size === 0) {
@@ -1063,8 +1074,6 @@ const notifyInvoicingResponsible = async () => {
       console.warn(`No email for responsible employee ${responsibleId}, skipping`);
       continue;
     }
-    if (TEST_USER_EMAIL && email.toLowerCase() !== TEST_USER_EMAIL) continue;
-
     const targetUser = pickSlackRecipient(slackUsers, email);
     if (!targetUser) {
       console.error(`No Slack user found for ${email}`);


### PR DESCRIPTION
## Hva

Ny flow `notifyInvoicingResponsible`, gated by `IS_INVOICING_REMINDER`, som DM-er hver prosjekts **oppdragsansvarlig** (`projects.responsible`) en påminnelse om å fakturere for måneden som nettopp ble avsluttet, med en liste over de aktive billable-prosjektene de eier.

## Sendedag-regel (fra issuen)

> «Hvis 31. er virkedag, reminder den dagen. Hvis 31. er lørdag, reminder på mandag.»

Påminnelsen lander på månedens siste dag hvis den er en virkedag; ellers rulles den **fremover** til neste virkedag (forbi helg _og_ helligdager, via `/holidays`). Fordi en fremoverrulling fra en helg/helligdag-månedsslutt havner i neste måned, evaluerer flowen to kandidater per kjøring (rulling fra denne månedens og forrige månedens siste dag) og fyrer hvis dagens dato matcher én av dem — så den sender på nøyaktig **én dag per måned**, uten dobbel-sending.

## Verifisert

| dato | resultat | dekker |
| --- | --- | --- |
| lør 31. mai 2025 (månedsslutt) | hopper over (ruller frem) | — |
| man 2. jun 2025 | **sender** | mai 2025 |
| man 31. mar 2025 (virkedag månedsslutt) | **sender** | mars 2025 |
| tor 2. jan 2023 (31. des lør + 1. jan helligdag) | **sender** | desember 2022 |
| midt i måneden | hopper over | — |

## Scheduling (må gjøres før merge/deploy)

Cloud Scheduler-triggeren må fyre denne **hver virkedag** med `IS_INVOICING_REMINDER=true` — flowen selv-gater til riktig dag. En fast månedlig cron kan ikke treffe, siden sendedatoen flytter seg fra måned til måned. Triggeren er **ikke** satt opp ennå.

`INVOICING_REMINDER_FORCE=true` omgår gaten for testing (dekker forrige måned).

### Slik legger du til cron-jobben

1. **Finn region og kopier oppsettet fra en eksisterende trigger** (for å speile auth/service-account og body-format):
   ```
   gcloud scheduler jobs list --location=europe-north1 --project=marine-cycle-97212
   gcloud scheduler jobs describe floq-prod-timebot-monday-digest \
     --location=europe-north1 --project=marine-cycle-97212 --format=yaml
   ```
   Noter `--location`, `oauthToken.serviceAccountEmail` og `httpTarget.uri`/body-format fra outputen.
2. **Opprett den nye triggeren** som fyrer man–fre kl. 09 og setter `IS_INVOICING_REMINDER=true` som container-override (bytt ut service-account med den fra steg 1):
   ```
   gcloud scheduler jobs create http floq-prod-timebot-invoicing-reminder \
     --project=marine-cycle-97212 \
     --location=europe-north1 \
     --schedule="0 9 * * 1-5" \
     --time-zone="Europe/Oslo" \
     --uri="https://run.googleapis.com/v2/projects/marine-cycle-97212/locations/europe-north1/jobs/floq-prod-timebot:run" \
     --http-method=POST \
     --headers="Content-Type=application/json" \
     --oauth-service-account-email="<SA fra steg 1>" \
     --oauth-token-scope="https://www.googleapis.com/auth/cloud-platform" \
     --message-body='{"overrides":{"containerOverrides":[{"env":[{"name":"IS_INVOICING_REMINDER","value":"true"}]}]}}'
   ```
3. **Verifiser** at triggeren finnes og har riktig schedule/body:
   ```
   gcloud scheduler jobs describe floq-prod-timebot-invoicing-reminder \
     --location=europe-north1 --project=marine-cycle-97212 --format=yaml
   ```
4. **Tørrkjør** én gang for å se meldingen uten å sende (bruk force for å omgå sendedag-gaten):
   ```
   gcloud run jobs execute floq-prod-timebot \
     --region=europe-north1 --project=marine-cycle-97212 \
     --update-env-vars=IS_INVOICING_REMINDER=true,INVOICING_REMINDER_FORCE=true,DRY_RUN=true
   ```
   Sjekk loggen for `DRY_RUN — message preview`.
5. **(Valgfritt) Trigger manuelt** for å bekrefte hele oppsettet ende-til-ende:
   ```
   gcloud scheduler jobs run floq-prod-timebot-invoicing-reminder \
     --location=europe-north1 --project=marine-cycle-97212
   ```
